### PR TITLE
Remove absolute paths, this is an issue if you mount resque-web in a rails app

### DIFF
--- a/lib/resque_cleaner/server/views/cleaner.erb
+++ b/lib/resque_cleaner/server/views/cleaner.erb
@@ -1,4 +1,4 @@
-<link href="/cleaner/public/cleaner.css" media="screen" rel="stylesheet" type="text/css">
+<link href="cleaner/public/cleaner.css" media="screen" rel="stylesheet" type="text/css">
 
 <div class="cleaner">
   <div class="title clearfix">
@@ -18,22 +18,22 @@
     <% @stats.each do |klass,count| %>
       <tr>
         <td><%= klass %></td>
-        <td class="number"><a href="/cleaner_list?c=<%=klass%>"><%= count["total"] %></a></td>
-        <td class="number"><a href="/cleaner_list?c=<%=klass%>&f=1"><%= count["1h"] %></a></td>
-        <td class="number"><a href="/cleaner_list?c=<%=klass%>&f=3"><%= count["3h"] %></a></td>
-        <td class="number"><a href="/cleaner_list?c=<%=klass%>&f=24"><%= count["1d"] %></a></td>
-        <td class="number"><a href="/cleaner_list?c=<%=klass%>&f=72"><%= count["3d"] %></a></td>
-        <td class="number"><a href="/cleaner_list?c=<%=klass%>&f=168"><%= count["7d"] %></a></td>
+        <td class="number"><a href="cleaner_list?c=<%=klass%>"><%= count["total"] %></a></td>
+        <td class="number"><a href="cleaner_list?c=<%=klass%>&f=1"><%= count["1h"] %></a></td>
+        <td class="number"><a href="cleaner_list?c=<%=klass%>&f=3"><%= count["3h"] %></a></td>
+        <td class="number"><a href="cleaner_list?c=<%=klass%>&f=24"><%= count["1d"] %></a></td>
+        <td class="number"><a href="cleaner_list?c=<%=klass%>&f=72"><%= count["3d"] %></a></td>
+        <td class="number"><a href="cleaner_list?c=<%=klass%>&f=168"><%= count["7d"] %></a></td>
       </tr>
     <% end %>
     <tr class="total">
       <td>Total</td>
-      <td class="number"><a href="/cleaner_list"><%= @total["total"] %></a></td>
-      <td class="number"><a href="/cleaner_list?f=1"><%= @total["1h"] %></a></td>
-      <td class="number"><a href="/cleaner_list?f=3"><%= @total["3h"] %></a></td>
-      <td class="number"><a href="/cleaner_list?f=24"><%= @total["1d"] %></a></td>
-      <td class="number"><a href="/cleaner_list?f=72"><%= @total["3d"] %></a></td>
-      <td class="number"><a href="/cleaner_list?f=168"><%= @total["7d"] %></a></td>
+      <td class="number"><a href="cleaner_list"><%= @total["total"] %></a></td>
+      <td class="number"><a href="cleaner_list?f=1"><%= @total["1h"] %></a></td>
+      <td class="number"><a href="cleaner_list?f=3"><%= @total["3h"] %></a></td>
+      <td class="number"><a href="cleaner_list?f=24"><%= @total["1d"] %></a></td>
+      <td class="number"><a href="cleaner_list?f=72"><%= @total["3d"] %></a></td>
+      <td class="number"><a href="cleaner_list?f=168"><%= @total["7d"] %></a></td>
     </tr>
   </table>
 

--- a/lib/resque_cleaner/server/views/cleaner_exec.erb
+++ b/lib/resque_cleaner/server/views/cleaner_exec.erb
@@ -1,4 +1,4 @@
-<link href="/cleaner/public/cleaner.css" media="screen" rel="stylesheet" type="text/css">
+<link href="cleaner/public/cleaner.css" media="screen" rel="stylesheet" type="text/css">
 
 <div class="cleaner">
   <p class="message"><%= @msg %></p>

--- a/lib/resque_cleaner/server/views/cleaner_list.erb
+++ b/lib/resque_cleaner/server/views/cleaner_list.erb
@@ -1,4 +1,4 @@
-<link href="/cleaner/public/cleaner.css" media="screen" rel="stylesheet" type="text/css">
+<link href="cleaner/public/cleaner.css" media="screen" rel="stylesheet" type="text/css">
 
 <!-- Many code was copied from failed.erb of the original resque -->
 <div class="cleaner">
@@ -26,7 +26,7 @@
   <% if @count > 0 %>
     <div class="clearfix">
       <div class="control_panel sub_header">
-        <form method="post" id="exec" action="/cleaner_exec">
+        <form method="post" id="exec" action="cleaner_exec">
           <input type="hidden" name="c" value="<%=@klass%>" />
           <input type="hidden" name="f" value="<%=@from%>" />
           <input type="hidden" name="t" value="<%=@to%>" />


### PR DESCRIPTION
removed absolute paths from html so when you mount resque-web in a rails app, the links/forms don't break

All the tests still pass so this shouldn't break any existing functionality. Would love to see this merged and pushed to the gem :)
