### PR TITLE
[Bugfix] Jobs without payload are ignored

### DIFF
--- a/lib/resque_cleaner.rb
+++ b/lib/resque_cleaner.rb
@@ -226,7 +226,10 @@ module Resque
           jobs = @cleaner.failure.all( index, count)
           jobs = [] unless jobs
           jobs = [jobs] unless jobs.is_a?(Array)
-          jobs.each{|j| j.extend FailedJobEx}
+          jobs = jobs.select do |job|
+            job.extend FailedJobEx
+            job && job["payload"]
+          end
           jobs
         end
 


### PR DESCRIPTION
This bugfix is probably for a weird edge case that only our server has experienced, but I figured I'd send a pull request anyway.

All I know is that this fixed the problem we had on our server: resque-cleaner raising an error when listing jobs. Upon following the stack trace, I discovered that in most of the sinatra url handlers (GET /cleaner, /cleaner_list,e tc.), code is called in a loop for all jobs:

```
job["payload"]["class"] # assumption: job is a Hash and job["payload"] is a Hash as well
```

In our case, this caused an error saying that nil did not respond to :[]. So job or job["payload"] was nil.

The patch (ab)uses a loop in the job collector to discard all nil jobs/payloads so that the code will not raise an error, but instead it ignores those jobs.

This allowed me to list & restart our failed jobs.
