### PR TITLE
Wrap up requeue and remove failed job in a transaction for safety

### DIFF
--- a/lib/resque_cleaner.rb
+++ b/lib/resque_cleaner.rb
@@ -118,17 +118,20 @@ module Resque
             if !block_given? || block.call(job)
               index = @limiter.start_index + i - requeued
 
-              if clear_after_requeue
-                # remove job
-                value = redis.lindex(:failed, index)
-                redis.lrem(:failed, 1, value)
-              else
-                # mark retried
-                job['retried_at'] = Time.now.strftime("%Y/%m/%d %H:%M:%S")
-                redis.lset(:failed, @limiter.start_index+i, Resque.encode(job))
+              value = redis.lindex(:failed, index)
+              redis.multi do
+                Job.create(queue||job['queue'], job['payload']['class'], *job['payload']['args'])
+
+                if clear_after_requeue
+                  # remove job
+                  redis.lrem(:failed, 1, value)
+                else
+                  # mark retried
+                  job['retried_at'] = Time.now.strftime("%Y/%m/%d %H:%M:%S")
+                  redis.lset(:failed, @limiter.start_index+i, Resque.encode(job))
+                end
               end
 
-              Job.create(queue||job['queue'], job['payload']['class'], *job['payload']['args'])
               requeued += 1
             end
           end


### PR DESCRIPTION
The previous logic could allow a job to be removed before it was requeued. In the event that something went wrong in the interval, the job could be completely lost. For safety this should be wrapped up in a [Redis transaction](http://redis.io/topics/transactions) to make sure either it is requeued AND removed, or neither.  This pull request makes those changes.

Note that the logic is also reversed so that it reads more clearly (i.e. the `clear_after_requeue` block actually happens after requeue in the code).
