### PR TITLE
update gemspec metadata

### DIFF
--- a/resque-cleaner.gemspec
+++ b/resque-cleaner.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
   s.homepage          = "https://github.com/ono/resque-cleaner"
   s.email             = "ononoma@gmail.com"
   s.authors           = [ "Tatsuya Ono" ]
+  s.license           = "MIT"
 
   s.files             = %w( README.markdown CHANGELOG.md Rakefile LICENSE )
   s.files            += Dir.glob("lib/**/*")


### PR DESCRIPTION
This pull request updates two things in the gemspec metadata.
- Use HTTPS for the homepage URL.
- Add MIT license metadata to allow RubyGems.org and other tools (such as gem2rpm) to report a license for your gem.
