### PR TITLE
Set max jobs searchable

### DIFF
--- a/lib/resque_cleaner/server.rb
+++ b/lib/resque_cleaner/server.rb
@@ -146,10 +146,14 @@ module ResqueCleaner
 
           block = filter_block
 
-          @failed = cleaner.select(&block).reverse
+          if @max_failures && @max_failures.respond_to?(:to_i)
+            cleaner.limiter.maximum = @max_failures.to_i
+          end
 
+          @failed = cleaner.select(&block).reverse
+          
           url = "cleaner_list?c=#{@klass}&ex=#{@exception}&f=#{@from}&t=#{@to}&regex=#{URI.encode(@regex || "")}"
-          @dump_url = "cleaner_dump?c=#{@klass}&ex=#{@exception}&f=#{@from}&t=#{@to}&regex=#{URI.encode(@regex || "")}"
+          @dump_url = "cleaner_dump?c=#{@klass}&ex=#{@exception}&f=#{@from}&t=#{@to}&regex=#{URI.encode(@regex || "")}&max=#{URI.encode(@max_failures || "")}"
           @paginate = Paginate.new(@failed, url, params[:p].to_i)
 
           @klasses = cleaner.stats_by_class.keys
@@ -225,6 +229,7 @@ module ResqueCleaner
       @klass = params[:c]=="" ? nil : params[:c]
       @exception = params[:ex]=="" ? nil : params[:ex]
       @regex = params[:regex]=="" ? nil : params[:regex]
+      @max_failures = params[:max]=="" ? nil : params[:max]
     end
 
     def filter_block

--- a/lib/resque_cleaner/server/views/cleaner_list.erb
+++ b/lib/resque_cleaner/server/views/cleaner_list.erb
@@ -24,6 +24,9 @@
         <span class="regex_filter">
           Regex: <%= text_filter("filter_regex", "regex", Rack::Utils.escape_html(@regex))%>
         </span>
+        <span class="max_failures_filter">
+          Max Failures: <%= text_filter("max_failures", "max", Rack::Utils.escape_html(@max_failures))%>
+        </span>
         <input type="submit" value="Filter" />
       </form>
     </div>


### PR DESCRIPTION
Sometimes, we have more than 1000 failed jobs in the queue, but we still want to see them in The Cleaner.  To address this, we add a parameter, `Max Failures` that lets us get any number of failed jobs from the Failed queue and show them in The Cleaner.
