### PR TITLE
Fix rendering the cleaner page on Ruby 3

### DIFF
--- a/lib/resque_cleaner/server.rb
+++ b/lib/resque_cleaner/server.rb
@@ -230,7 +230,7 @@ module ResqueCleaner
         f: @from,
         t: @to,
         regex: @regex
-      }.map {|key,value| "#{key}=#{URI.encode(value.to_s)}"}.join("&")
+      }.map {|key,value| "#{key}=#{CGI.escape(value.to_s)}"}.join("&")
 
       @list_url = "cleaner_list?#{params}"
       @dump_url = "cleaner_dump?#{params}"

--- a/lib/resque_cleaner/server/views/_stats.erb
+++ b/lib/resque_cleaner/server/views/_stats.erb
@@ -10,7 +10,7 @@
   </tr>
   <% @stats[type.to_sym].each do |field,count| %>
     <tr>
-      <% filter = "#{q}=#{URI.encode(field)}" %>
+      <% filter = "#{q}=#{CGI.escape(field)}" %>
       <td><%= field %></td>
       <td class="number">
         <a href="cleaner_list?<%=filter%>"><%= count[:total] %></a>


### PR DESCRIPTION
What?
-
Makes the cleaner page work on Ruby 3.

Screenshots
-
Before:
![135488904-0bc00d45-57dc-4ac2-8ba9-77c22bad037b](https://user-images.githubusercontent.com/1948197/135489341-043697ab-fc71-408b-8b00-38bc3600946e.png)

After:
<img width="792" alt="Resque 2021-09-30 21-26-37" src="https://user-images.githubusercontent.com/1948197/135489824-2b041437-2419-4ac5-8558-f28373694b31.png">

Notes
-
This PR is similar to https://github.com/resque/resque-scheduler/commit/e7e2531c2486f38aaacf0c0ce687fadff6aa5f2e.

@ono I'm aware of https://github.com/ono/resque-cleaner/issues/47 but hoping we can get this in because it is tiny and makes the gem work with Ruby 3 :)